### PR TITLE
sessionstorage for contentid 

### DIFF
--- a/src/components/pages/Pages.jsx
+++ b/src/components/pages/Pages.jsx
@@ -50,7 +50,7 @@ const Pages = () => {
             <Link
               to={`/texts/text-details?text_id=${id}`}
               className="continue-button navbaritems"
-              state={{chapterInformation: {contentId: contentId || "", versionId: ""}}}
+              state={{chapterInformation: {contentId: contentId || "", versionId: "",contentindex:0}}}
             >
               {t("text.button.continue_reading")}
             </Link>

--- a/src/components/pages/Pages.jsx
+++ b/src/components/pages/Pages.jsx
@@ -21,10 +21,10 @@ const Pages = () => {
     if (location.state?.chapterInformation?.contentId) {
       const newContentId = location.state.chapterInformation.contentId;
       setContentId(newContentId);
-      localStorage.setItem(`text_${id}_contentId`, newContentId);
+      sessionStorage.setItem(`text_${id}_contentId`, newContentId);
     }
     else {
-      const savedContentId = localStorage.getItem(`text_${id}_contentId`);
+      const savedContentId = sessionStorage.getItem(`text_${id}_contentId`);
       if (savedContentId) {
         setContentId(savedContentId);
       }
@@ -34,7 +34,7 @@ const Pages = () => {
   const handleContentSelect = (newContentId) => {
     if (newContentId) {
       setContentId(newContentId);
-      localStorage.setItem(`text_${id}_contentId`, newContentId);
+      sessionStorage.setItem(`text_${id}_contentId`, newContentId);
     }
   };
 

--- a/src/components/pages/Pages.jsx
+++ b/src/components/pages/Pages.jsx
@@ -17,27 +17,6 @@ const Pages = () => {
   const { t } = useTranslate();
   const { id } = useParams();
 
-  useEffect(() => {
-    if (location.state?.chapterInformation?.contentId) {
-      const newContentId = location.state.chapterInformation.contentId;
-      setContentId(newContentId);
-      sessionStorage.setItem(`text_${id}_contentId`, newContentId);
-    }
-    else {
-      const savedContentId = sessionStorage.getItem(`text_${id}_contentId`);
-      if (savedContentId) {
-        setContentId(savedContentId);
-      }
-    }
-  }, [location.state, id]);
-
-  const handleContentSelect = (newContentId) => {
-    if (newContentId) {
-      setContentId(newContentId);
-      sessionStorage.setItem(`text_${id}_contentId`, newContentId);
-    }
-  };
-
   return (
     <div className="pecha-app">
       <main className="main-content">
@@ -62,10 +41,10 @@ const Pages = () => {
             className="custom-tabs listsubtitle"
           >
             <Tab eventKey="contents" title={t("text.contents")}>
-              <Content onContentSelect={handleContentSelect} currentContentId={contentId} />
+              <Content setContentId={setContentId}/>
             </Tab>
             <Tab eventKey="versions" title={t("common.version")}>
-              <Versions contentId={contentId} onContentIdChange={handleContentSelect} />
+              <Versions contentId={contentId} />
             </Tab>
           </Tabs>
         </div>

--- a/src/components/pages/Pages.jsx
+++ b/src/components/pages/Pages.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Tabs, Tab } from 'react-bootstrap';
 import './Pages.scss';
 import { FiChevronDown } from 'react-icons/fi';
@@ -16,6 +16,28 @@ const Pages = () => {
   const titleInformation = location.state?.titleInformation || "";
   const { t } = useTranslate();
   const { id } = useParams();
+
+  useEffect(() => {
+    if (location.state?.chapterInformation?.contentId) {
+      const newContentId = location.state.chapterInformation.contentId;
+      setContentId(newContentId);
+      localStorage.setItem(`text_${id}_contentId`, newContentId);
+    }
+    else {
+      const savedContentId = localStorage.getItem(`text_${id}_contentId`);
+      if (savedContentId) {
+        setContentId(savedContentId);
+      }
+    }
+  }, [location.state, id]);
+
+  const handleContentSelect = (newContentId) => {
+    if (newContentId) {
+      setContentId(newContentId);
+      localStorage.setItem(`text_${id}_contentId`, newContentId);
+    }
+  };
+
   return (
     <div className="pecha-app">
       <main className="main-content">
@@ -40,10 +62,10 @@ const Pages = () => {
             className="custom-tabs listsubtitle"
           >
             <Tab eventKey="contents" title={t("text.contents")}>
-              <Content onContentSelect={setContentId} />
+              <Content onContentSelect={handleContentSelect} currentContentId={contentId} />
             </Tab>
             <Tab eventKey="versions" title={t("common.version")}>
-              <Versions contentId={contentId} />
+              <Versions contentId={contentId} onContentIdChange={handleContentSelect} />
             </Tab>
           </Tabs>
         </div>

--- a/src/components/pages/content/Content.jsx
+++ b/src/components/pages/content/Content.jsx
@@ -20,34 +20,24 @@ export const fetchTextContent = async (text_id) => {
   return data;
 };
 
-const Content = ({ onContentSelect, currentContentId }) => {
+const Content = ({ setContentId }) => {
   const [expandedSections, setExpandedSections] = useState({});
   const { id } = useParams();
   const { t } = useTranslate();
   const [pagination, setPagination] = useState({ currentPage: 1, limit: 10 });
   const skip = useMemo(() => (pagination.currentPage - 1) * pagination.limit, [pagination]);
-  const { data: apiData, isLoading, error } = useQuery(
+  const {data: apiData, isLoading, error} = useQuery(
     ["texts", id],
     () => fetchTextContent(id),
     {
       refetchOnWindowFocus: false,
-      staleTime: 1000 * 60 * 20,
       retry: 1,
       onSuccess: (data) => {
-        if (data?.contents && data.contents.length > 0) {
-          // Only set the content ID if it's not already set
-          if (!currentContentId) {
-            const firstContentId = data.contents[0].id;
-            onContentSelect(firstContentId);
-          }
-        }
+        setContentId(data.contents[0].id);
       }
     }
   );
 
-  const handleContentClick = (contentId) => {
-    onContentSelect(contentId);
-  };
 
   if (isLoading) return <div className="listsubtitle">{t("common.loading")}</div>;
   
@@ -99,10 +89,6 @@ const Content = ({ onContentSelect, currentContentId }) => {
             to={`/texts/text-details?text_id=${id}`}
             className={`section-title ${getLanguageClass(apiData.text_detail.language)}`}
             state={{chapterInformation: {contentId: contentId, versionId: ""}}}
-            onClick={(e) => {
-              e.stopPropagation(); 
-              handleContentClick(contentId);
-            }}
           >
             {section.title}
           </Link>
@@ -149,10 +135,6 @@ const Content = ({ onContentSelect, currentContentId }) => {
                     to={`/texts/text-details?text_id=${id}`}
                     className={`section-title ${getLanguageClass(apiData.text_detail.language)}`}
                     state={{chapterInformation: {contentId: content.id, versionId: "", contentindex:index}}}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      handleContentClick(content.id);
-                    }}
                   >
                     {segment.title}
                   </Link>

--- a/src/components/pages/content/Content.jsx
+++ b/src/components/pages/content/Content.jsx
@@ -7,14 +7,14 @@ import { useQuery } from 'react-query';
 import { useParams, Link } from 'react-router-dom';
 import PaginationComponent from '../../commons/pagination/PaginationComponent';
 import { useTranslate } from "@tolgee/react";
-export const fetchTextContent = async (text_id) => {
+export const fetchTextContent = async (text_id, skip, pagination) => {
   const storedLanguage = sessionStorage.getItem(LANGUAGE);
   const language = (storedLanguage ? mapLanguageCode(storedLanguage) : "bo");
   const {data} = await axiosInstance.get(`/api/v1/texts/${text_id}/contents`, {
     params: {
       language,
-      limit: 10,
-      skip: 0
+      limit: pagination.limit,
+      skip: skip
     }
   });
   return data;
@@ -27,8 +27,8 @@ const Content = ({ setContentId }) => {
   const [pagination, setPagination] = useState({ currentPage: 1, limit: 10 });
   const skip = useMemo(() => (pagination.currentPage - 1) * pagination.limit, [pagination]);
   const {data: apiData, isLoading, error} = useQuery(
-    ["texts", id],
-    () => fetchTextContent(id),
+    ["texts", id, skip,pagination],
+    () => fetchTextContent(id,skip,pagination),
     {
       refetchOnWindowFocus: false,
       retry: 1,

--- a/src/components/pages/content/Content.jsx
+++ b/src/components/pages/content/Content.jsx
@@ -8,7 +8,7 @@ import { useParams, Link } from 'react-router-dom';
 import PaginationComponent from '../../commons/pagination/PaginationComponent';
 import { useTranslate } from "@tolgee/react";
 export const fetchTextContent = async (text_id, skip, pagination) => {
-  const storedLanguage = sessionStorage.getItem(LANGUAGE);
+  const storedLanguage = localStorage.getItem(LANGUAGE);
   const language = (storedLanguage ? mapLanguageCode(storedLanguage) : "bo");
   const {data} = await axiosInstance.get(`/api/v1/texts/${text_id}/contents`, {
     params: {

--- a/src/components/pages/content/Content.jsx
+++ b/src/components/pages/content/Content.jsx
@@ -57,16 +57,6 @@ const Content = ({ onContentSelect, currentContentId }) => {
     return <div className="no-content listtitle">No content found</div>;
   }
 
-  // useEffect(() => {
-  //   if (apiData?.contents?.[0]?.segments) {
-  //     const initialExpandedState = {};
-  //     // Only set the first level segments to expanded
-  //     apiData.contents[0].segments.forEach(segment => {
-  //       initialExpandedState[segment.id] = true;
-  //     });
-  //     setExpandedSections(initialExpandedState);
-  //   }
-  // }, [apiData]);
 
   const contents = apiData?.contents;
   const totalSections = contents.reduce((total, content) => {

--- a/src/components/pages/content/Content.jsx
+++ b/src/components/pages/content/Content.jsx
@@ -8,7 +8,7 @@ import { useParams, Link } from 'react-router-dom';
 import PaginationComponent from '../../commons/pagination/PaginationComponent';
 import { useTranslate } from "@tolgee/react";
 export const fetchTextContent = async (text_id) => {
-  const storedLanguage = localStorage.getItem(LANGUAGE);
+  const storedLanguage = sessionStorage.getItem(LANGUAGE);
   const language = (storedLanguage ? mapLanguageCode(storedLanguage) : "bo");
   const {data} = await axiosInstance.get(`/api/v1/texts/${text_id}/contents`, {
     params: {

--- a/src/components/pages/versions/Versions.jsx
+++ b/src/components/pages/versions/Versions.jsx
@@ -21,7 +21,8 @@ export const fetchVersions = async (id, limit, skip) => {
   })
   return data
 }
-const Versions = ({ contentId }) =>{
+
+const Versions = ({ contentId, onContentIdChange }) => {
   const { id } = useParams();
   const { t } = useTranslate();
   const [pagination, setPagination] = useState({ currentPage: 1, limit: 10 });
@@ -29,7 +30,7 @@ const Versions = ({ contentId }) =>{
 
 
   const { data: versionsData, isLoading } = useQuery(
-    ["texts", id, pagination.currentPage, pagination.limit],
+    ["texts-versions", id, pagination.currentPage, pagination.limit],
     () => fetchVersions(id, pagination.limit, skip),
     {
       refetchOnWindowFocus: false,
@@ -42,6 +43,15 @@ const Versions = ({ contentId }) =>{
     "bo":"language.tibetan",
     "en":"language.english"
   }
+
+  const handleVersionClick = () => {
+    if (!contentId) {
+      const savedContentId = localStorage.getItem(`text_${id}_contentId`);
+      if (savedContentId) {
+        onContentIdChange(savedContentId);
+      }
+    }
+  };
 
   if (isLoading) {
     return <div className="notfound listtitle">Loading versions...</div>;
@@ -76,6 +86,7 @@ const Versions = ({ contentId }) =>{
                   to={`/texts/text-details?text_id=${id}`}
                   className="section-title"
                   state={{chapterInformation: {contentId: contentId, versionId: version.id}}}
+                  onClick={handleVersionClick}
                 >
                   <div className={`${getLanguageClass(version.language)} titleversion`}>
                     {version.title}

--- a/src/components/pages/versions/Versions.jsx
+++ b/src/components/pages/versions/Versions.jsx
@@ -22,7 +22,7 @@ export const fetchVersions = async (id, limit, skip) => {
   return data
 }
 
-const Versions = ({ contentId, onContentIdChange }) => {
+const Versions = ({ contentId }) => {
   const { id } = useParams();
   const { t } = useTranslate();
   const [pagination, setPagination] = useState({ currentPage: 1, limit: 10 });
@@ -34,7 +34,6 @@ const Versions = ({ contentId, onContentIdChange }) => {
     () => fetchVersions(id, pagination.limit, skip),
     {
       refetchOnWindowFocus: false,
-      staleTime: 1000 * 60 * 20,
       retry: 1
     }
   );
@@ -44,14 +43,6 @@ const Versions = ({ contentId, onContentIdChange }) => {
     "en":"language.english"
   }
 
-  const handleVersionClick = () => {
-    if (!contentId) {
-      const savedContentId = sessionStorage.getItem(`text_${id}_contentId`);
-      if (savedContentId) {
-        onContentIdChange(savedContentId);
-      }
-    }
-  };
 
   if (isLoading) {
     return <div className="notfound listtitle">Loading versions...</div>;
@@ -86,7 +77,6 @@ const Versions = ({ contentId, onContentIdChange }) => {
                   to={`/texts/text-details?text_id=${id}`}
                   className="section-title"
                   state={{chapterInformation: {contentId: contentId, versionId: version.id,contentindex:0}}}
-                  onClick={handleVersionClick}
                 >
                   <div className={`${getLanguageClass(version.language)} titleversion`}>
                     {version.title}

--- a/src/components/pages/versions/Versions.jsx
+++ b/src/components/pages/versions/Versions.jsx
@@ -9,7 +9,7 @@ import PaginationComponent from "../../commons/pagination/PaginationComponent.js
 
 
 export const fetchVersions = async (id, limit, skip) => {
-  const storedLanguage = localStorage.getItem(LANGUAGE);
+  const storedLanguage = sessionStorage.getItem(LANGUAGE);
   const language = storedLanguage ? mapLanguageCode(storedLanguage) : "bo";
 
   const {data} = await axiosInstance.get(`/api/v1/texts/${id}/versions`, {
@@ -46,7 +46,7 @@ const Versions = ({ contentId, onContentIdChange }) => {
 
   const handleVersionClick = () => {
     if (!contentId) {
-      const savedContentId = localStorage.getItem(`text_${id}_contentId`);
+      const savedContentId = sessionStorage.getItem(`text_${id}_contentId`);
       if (savedContentId) {
         onContentIdChange(savedContentId);
       }
@@ -85,7 +85,7 @@ const Versions = ({ contentId, onContentIdChange }) => {
                   // TODO to={`/texts/text-details?text_id=${id}&version_id=${version.id}`}
                   to={`/texts/text-details?text_id=${id}`}
                   className="section-title"
-                  state={{chapterInformation: {contentId: contentId, versionId: version.id}}}
+                  state={{chapterInformation: {contentId: contentId, versionId: version.id,contentindex:0}}}
                   onClick={handleVersionClick}
                 >
                   <div className={`${getLanguageClass(version.language)} titleversion`}>


### PR DESCRIPTION
yesterday, me and tsering discuss about how contentid should be pass. the thing was from backend it was not being able to pass the content id . so keeping that in mind what i did was a bit of a prop passing state, for that the initial was working fine. but when we navigate back and forth and then click on any one of the version. the content id was getting perish leading to a empty contentid.

so this pr tackles this issue by introducing localstorage . when we initially load the contentid, it stores in that. and it is used all across the navigation.

cc @sachmundassery 