### PR TITLE
fix : redirect fixes and loading state for buildin auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest",
-    "coverage": "vitest run --coverage"
+    "coverage": "vitest run --coverage",
+    "mac:coverage": "vitest run --coverage && open coverage/index.html"
   },
   "dependencies": {
     "@auth0/auth0-react": "^2.2.4",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,7 +8,7 @@ sonar.tests=src
 
 # Test configurations
 sonar.test.inclusions=**/*.test.js,**/*.test.jsx,**/*.test.ts,**/*.test.tsx
-sonar.exclusions=**/*.test.js,**/*.test.jsx,**/*.test.ts,**/*.test.tsx,**/node_modules/**,**/coverage/**
+sonar.exclusions=**/*.test.js,**/*.test.jsx,**/*.test.ts,**/*.test.tsx,**/node_modules/**,**/coverage/**,src/config/**
 
 # Coverage reports
 sonar.javascript.lcov.reportPaths=coverage/lcov.info

--- a/src/components/community/CommunityPage.jsx
+++ b/src/components/community/CommunityPage.jsx
@@ -77,14 +77,7 @@ const CommunityPage = () => {
         <div className='sidebar-section'>
           <div className='sidebar-content navbaritems'>
             <p>{t("side_nav.join_conversation.descriptions")}</p>
-            <button className='make-sheet-btn navbaritems' onClick={() => {
-              if (isLoggedIn) {
-                navigate("/sheets");
-              } else {
-                sessionStorage.setItem('redirectAfterLogin', '/sheets');
-                navigate("/login");
-              }
-            }}>
+            <button className='make-sheet-btn navbaritems' onClick={() => navigate("/sheets")}>
               <span className='btn-icon'></span>
               {t("side_nav.join_conversation.button.make_sheet")}
             </button>

--- a/src/components/community/CommunityPage.jsx
+++ b/src/components/community/CommunityPage.jsx
@@ -6,6 +6,8 @@ import { useQuery } from 'react-query';
 import axiosInstance from '../../config/axios-config.js';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../config/AuthContext.jsx';
+import { useAuth0 } from '@auth0/auth0-react';
+
 export const fetchsheet = async (userid="", limit, skip) => {
     const storedLanguage = localStorage.getItem(LANGUAGE);
     const language = storedLanguage ? mapLanguageCode(storedLanguage) : "bo";
@@ -25,6 +27,7 @@ const CommunityPage = () => {
     const [limit, setLimit] = useState(10);
     const navigate = useNavigate();
     const { isLoggedIn } = useAuth();
+    const { isAuthenticated } = useAuth0();
       const skip = useMemo(() =>{
         return (currentPage - 1) * limit;
       },[currentPage])
@@ -39,6 +42,7 @@ const CommunityPage = () => {
     () => fetchsheet("tenzin_tsering.7233", limit, skip), 
     { refetchOnWindowFocus: false }
   );
+  const userIsLoggedIn = isLoggedIn || isAuthenticated;
   return (
     <div className='container-community'>
       <div className='sheet-community'>
@@ -77,7 +81,8 @@ const CommunityPage = () => {
         <div className='sidebar-section'>
           <div className='sidebar-content navbaritems'>
             <p>{t("side_nav.join_conversation.descriptions")}</p>
-            <button className='make-sheet-btn navbaritems' onClick={() => navigate("/sheets")}>
+            <button className='make-sheet-btn navbaritems' onClick={() => 
+              userIsLoggedIn ? navigate("/sheets") : navigate("/login")}>
               <span className='btn-icon'></span>
               {t("side_nav.join_conversation.button.make_sheet")}
             </button>

--- a/src/components/community/CommunityPage.test.jsx
+++ b/src/components/community/CommunityPage.test.jsx
@@ -155,6 +155,5 @@ describe("CommunityPage Component", () => {
     expect(makeSheetButton).toBeInTheDocument();
     expect(makeSheetButton).not.toBeDisabled();
     fireEvent.click(makeSheetButton);
-    expect(window.sessionStorage.setItem).toHaveBeenCalledWith('redirectAfterLogin', '/sheets');
   });
 });

--- a/src/components/navbar/NavigationBar.jsx
+++ b/src/components/navbar/NavigationBar.jsx
@@ -20,7 +20,7 @@ const NavigationBar = () => {
  const navigate = useNavigate();
  const { t } = useTranslate();
  const { isLoggedIn, logout: pechaLogout } = useAuth();
- const { isAuthenticated, logout } = useAuth0();
+ const { isAuthenticated, logout, isLoading: isAuth0Loading } = useAuth0();
  const tolgee = useTolgee(['language']);
  const queryClient = useQueryClient();
 
@@ -33,12 +33,6 @@ const NavigationBar = () => {
 
  function handleLogout(e) {
    e.preventDefault()
-   
-   const currentPath = window.location.pathname;
-   if (currentPath !== '/login' && currentPath !== '/register') {
-     sessionStorage.setItem('redirectAfterLogin', currentPath);
-   }
-   
    localStorage.removeItem(LOGGED_IN_VIA);
    sessionStorage.removeItem(ACCESS_TOKEN);
    localStorage.removeItem(REFRESH_TOKEN)
@@ -172,7 +166,11 @@ const NavigationBar = () => {
 
 
          <Nav className="d-flex align-items-lg-center navbaritems">
-           {(!isLoggedIn && !isAuthenticated) ? (
+           {isAuth0Loading ? (
+             <div>
+               Loading
+             </div>
+           ) : (!isLoggedIn && !isAuthenticated) ? (
              <div className="d-flex flex-column flex-lg-row">
                <Button as={Link} to="/login" variant="outline-dark" className="mb-2 mb-lg-0 me-lg-2" onClick={handleNavClick}>
                  {t("login.form.button.login_in")}
@@ -183,8 +181,6 @@ const NavigationBar = () => {
              </div>
            ) : (
              <Button
-              // as={ Link }
-              // to="/login"
                onClick={(e) => {
                  handleLogout(e);
                  handleNavClick();

--- a/src/components/navbar/NavigationBar.jsx
+++ b/src/components/navbar/NavigationBar.jsx
@@ -19,7 +19,7 @@ const NavigationBar = () => {
  const [searchTerm, setSearchTerm] = useState('');
  const navigate = useNavigate();
  const { t } = useTranslate();
- const { isLoggedIn, logout: pechaLogout } = useAuth();
+ const { isLoggedIn, logout: pechaLogout, isAuthLoading } = useAuth();
  const { isAuthenticated, logout, isLoading: isAuth0Loading } = useAuth0();
  const tolgee = useTolgee(['language']);
  const queryClient = useQueryClient();
@@ -166,9 +166,9 @@ const NavigationBar = () => {
 
 
          <Nav className="d-flex align-items-lg-center navbaritems">
-           {isAuth0Loading ? (
+           {isAuth0Loading || isAuthLoading ? (
              <div>
-               Loading
+               Loading...
              </div>
            ) : (!isLoggedIn && !isAuthenticated) ? (
              <div className="d-flex flex-column flex-lg-row">

--- a/src/components/sheets/local-components/UserProfileCard/ProfileCard.jsx
+++ b/src/components/sheets/local-components/UserProfileCard/ProfileCard.jsx
@@ -25,6 +25,7 @@ const ProfileCard = () => {
   if (userInfoIsLoading) {
     return <div className="profile-card-loading">Loading...</div>;
   }
+  console.log(userInfo)
   return (
     <div className="profile-card">
             {userInfo?.username || user?.name && (

--- a/src/components/sheets/local-components/UserProfileCard/ProfileCard.jsx
+++ b/src/components/sheets/local-components/UserProfileCard/ProfileCard.jsx
@@ -25,7 +25,6 @@ const ProfileCard = () => {
   if (userInfoIsLoading) {
     return <div className="profile-card-loading">Loading...</div>;
   }
-  console.log(userInfo)
   return (
     <div className="profile-card">
       {(userInfo?.username || user?.name) && (

--- a/src/components/sheets/local-components/UserProfileCard/ProfileCard.jsx
+++ b/src/components/sheets/local-components/UserProfileCard/ProfileCard.jsx
@@ -28,12 +28,10 @@ const ProfileCard = () => {
   console.log(userInfo)
   return (
     <div className="profile-card">
-            {userInfo?.username || user?.name && (
+      {(userInfo?.username || user?.name) && (
       <div className="profile-card-content">
         <div className="profile-picture-container">
-      
             <img src={userInfo?.avatar_url || user?.picture} alt="Profile" className="profile-image" />
-       
         </div>
         <div className="profile-info">
           <span className="profile-name">{capitalize(userInfo?.firstname || user?.given_name)} {capitalize(userInfo?.lastname || user?.family_name)}</span>
@@ -41,6 +39,7 @@ const ProfileCard = () => {
         </div>
       </div>
          )}
+         
     </div>
   );
 };

--- a/src/components/sheets/local-components/UserProfileCard/ProfileCard.jsx
+++ b/src/components/sheets/local-components/UserProfileCard/ProfileCard.jsx
@@ -1,9 +1,9 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useAuth } from '../../../../config/AuthContext.jsx';
 import { useQuery } from 'react-query';
-import { useNavigate } from 'react-router-dom';
 import axiosInstance from '../../../../config/axios-config.js';
 import './ProfileCard.scss';
+import { useAuth0 } from '@auth0/auth0-react';
 
 const fetchUserInfo = async () => {
   const { data } = await axiosInstance.get("/api/v1/users/info");
@@ -14,33 +14,29 @@ const capitalize = (str) => str ? str.charAt(0).toUpperCase() + str.slice(1).toL
 
 const ProfileCard = () => {
   const { isLoggedIn } = useAuth();
-  const navigate = useNavigate();
+  const { user } = useAuth0();
+
   const {
     data: userInfo,
     isLoading: userInfoIsLoading
   } = useQuery("userInfo", fetchUserInfo, { refetchOnWindowFocus: false, enabled: isLoggedIn });
 
-  useEffect(() => {
-    if (!isLoggedIn) {
-      navigate('/login');
-    }
-  }, [isLoggedIn, navigate]);
 
   if (userInfoIsLoading) {
     return <div className="profile-card-loading">Loading...</div>;
   }
   return (
     <div className="profile-card">
-            {userInfo?.username && (
+            {userInfo?.username || user?.name && (
       <div className="profile-card-content">
         <div className="profile-picture-container">
       
-            <img src={userInfo.avatar_url} alt="Profile" className="profile-image" />
+            <img src={userInfo?.avatar_url || user?.picture} alt="Profile" className="profile-image" />
        
         </div>
         <div className="profile-info">
-          <span className="profile-name">{capitalize(userInfo?.firstname)} {capitalize(userInfo?.lastname)}</span>
-          <span className="profile-title">@{userInfo.username}</span>
+          <span className="profile-name">{capitalize(userInfo?.firstname || user?.given_name)} {capitalize(userInfo?.lastname || user?.family_name)}</span>
+          <span className="profile-title">@{userInfo?.username || user?.nickname}</span>
         </div>
       </div>
          )}

--- a/src/components/sheets/local-components/UserProfileCard/ProfileCard.jsx
+++ b/src/components/sheets/local-components/UserProfileCard/ProfileCard.jsx
@@ -5,7 +5,7 @@ import axiosInstance from '../../../../config/axios-config.js';
 import './ProfileCard.scss';
 import { useAuth0 } from '@auth0/auth0-react';
 
-const fetchUserInfo = async () => {
+export const fetchUserInfo = async () => {
   const { data } = await axiosInstance.get("/api/v1/users/info");
   return data;
 };

--- a/src/components/sheets/local-components/UserProfileCard/ProfileCard.test.jsx
+++ b/src/components/sheets/local-components/UserProfileCard/ProfileCard.test.jsx
@@ -5,6 +5,8 @@ import ProfileCard from './ProfileCard';
 import { vi } from 'vitest';
 import { mockUseAuth, mockReactQuery } from '../../../../test-utils/CommonMocks.js';
 import { useQuery } from 'react-query';
+import axiosInstance from '../../../../config/axios-config.js';
+import { fetchUserInfo } from './ProfileCard.jsx';
 
 mockUseAuth();
 mockReactQuery();
@@ -43,5 +45,18 @@ describe('ProfileCard', () => {
     });
     render(<ProfileCard />);
     expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+});
+
+describe('fetchUserInfo', () => {
+  it('fetches user info with correct API call and returns data', async () => {
+    const mockData = { username: 'janedoe', firstname: 'Jane', lastname: 'Doe', avatar_url: 'https://example.com/jane.jpg' };
+    const mockResponse = { data: mockData };
+    const getSpy = vi.spyOn(axiosInstance, 'get').mockResolvedValueOnce(mockResponse);
+
+    const result = await fetchUserInfo();
+
+    expect(getSpy).toHaveBeenCalledWith('/api/v1/users/info');
+    expect(result).toEqual(mockData);
   });
 });

--- a/src/components/user-login/UserLogin.jsx
+++ b/src/components/user-login/UserLogin.jsx
@@ -3,7 +3,7 @@ import { useMutation } from "react-query";
 import { Button, Col, Container, Form, Row, Toast, ToastContainer } from "react-bootstrap";
 import "./UserLogin.scss";
 import axiosInstance from "../../config/axios-config";
-import { Link, useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import eyeOpen from "../../assets/icons/eye-open.svg";
 import eyeClose from "../../assets/icons/eye-closed.svg";
 import { useAuth0 } from "@auth0/auth0-react";
@@ -17,23 +17,10 @@ const UserLogin = () => {
     const [password, setPassword] = useState("");
     const [errors, setErrors] = useState({});
     const [showPassword, setShowPassword] = useState(false);
-    const { loginWithRedirect, isAuthenticated } = useAuth0();
-    const { login, isLoggedIn } = useAuth();
-    const navigate = useNavigate();
+    const { loginWithRedirect } = useAuth0();
+    const { login } = useAuth();
 
-    // Check if there's a redirect path stored in sessionStorage
-    const redirectPath = sessionStorage.getItem('redirectAfterLogin');
-    
-    if (isLoggedIn || isAuthenticated) {
-        // If there's a stored redirect path, navigate there and clear it
-        if (redirectPath) {
-            sessionStorage.removeItem('redirectAfterLogin');
-            navigate(redirectPath);
-        } else {
-            // Default redirect to texts page
-            navigate("/texts");
-        }
-    }
+
     const loginMutation = useMutation(
         async (loginData) => {
             const response = await axiosInstance.post(
@@ -47,16 +34,7 @@ const UserLogin = () => {
                 const accessToken = data.auth.access_token;
                 const refreshToken = data.auth.refresh_token;
                 login(accessToken, refreshToken);
-                
-                // Check if there's a redirect path stored in sessionStorage
-                const redirectPath = sessionStorage.getItem('redirectAfterLogin');
-                if (redirectPath) {
-                    sessionStorage.removeItem('redirectAfterLogin');
-                    navigate(redirectPath);
-                } else {
-                    // Default redirect to texts page
-                    navigate("/texts");
-                }
+                // navigate("/texts");
             },
             onError: (error) => {
                 console.error("Login failed", error);
@@ -107,7 +85,7 @@ const UserLogin = () => {
 
     const loginWithGoogle = async () => {
         try {
-            const redirectPath = sessionStorage.getItem('redirectAfterLogin') || "/texts";
+            const redirectPath ="/texts";
             
             await loginWithRedirect({
                 authorizationParams: {
@@ -118,9 +96,6 @@ const UserLogin = () => {
                     returnTo: redirectPath,
                 },
             });
-            if (sessionStorage.getItem('redirectAfterLogin')) {
-                sessionStorage.removeItem('redirectAfterLogin');
-            }
         } catch (error) {
             console.error("Google login failed:", error);
         }
@@ -128,8 +103,7 @@ const UserLogin = () => {
 
     const loginWithApple = async () => {
         try {
-            // Check if there's a redirect path stored in sessionStorage
-            const redirectPath = sessionStorage.getItem('redirectAfterLogin') || "/texts";
+            const redirectPath = "/texts";
             
             await loginWithRedirect({
                 authorizationParams: {
@@ -139,11 +113,7 @@ const UserLogin = () => {
                     returnTo: redirectPath,
                 },
             });
-            
-            // Clear the redirect path after using it
-            if (sessionStorage.getItem('redirectAfterLogin')) {
-                sessionStorage.removeItem('redirectAfterLogin');
-            }
+
         } catch (error) {
             console.error("Apple login failed:", error);
         }

--- a/src/components/user-login/UserLogin.jsx
+++ b/src/components/user-login/UserLogin.jsx
@@ -3,7 +3,7 @@ import { useMutation } from "react-query";
 import { Button, Col, Container, Form, Row, Toast, ToastContainer } from "react-bootstrap";
 import "./UserLogin.scss";
 import axiosInstance from "../../config/axios-config";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import eyeOpen from "../../assets/icons/eye-open.svg";
 import eyeClose from "../../assets/icons/eye-closed.svg";
 import { useAuth0 } from "@auth0/auth0-react";
@@ -19,7 +19,7 @@ const UserLogin = () => {
     const [showPassword, setShowPassword] = useState(false);
     const { loginWithRedirect } = useAuth0();
     const { login } = useAuth();
-
+    const navigate = useNavigate();
 
     const loginMutation = useMutation(
         async (loginData) => {
@@ -34,7 +34,7 @@ const UserLogin = () => {
                 const accessToken = data.auth.access_token;
                 const refreshToken = data.auth.refresh_token;
                 login(accessToken, refreshToken);
-                // navigate("/texts");
+                navigate("/texts");
             },
             onError: (error) => {
                 console.error("Login failed", error);

--- a/src/config/AuthContext.jsx
+++ b/src/config/AuthContext.jsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useMemo, useState } from "react";
+import React, { createContext, useContext, useMemo, useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { ACCESS_TOKEN, LOGGED_IN_VIA, REFRESH_TOKEN } from "../utils/Constants.js";
 
@@ -6,6 +6,19 @@ const AuthContext = createContext();
 
 export const PechaAuthProvider = ({ children }) => {
     const [isLoggedIn, setIsLoggedIn] = useState(false);
+    const [isAuthLoading, setIsAuthLoading] = useState(true);
+
+    useEffect(() => {
+        const accessToken = sessionStorage.getItem(ACCESS_TOKEN);
+        const refreshToken = localStorage.getItem(REFRESH_TOKEN);
+        const loggedInVia = localStorage.getItem(LOGGED_IN_VIA);
+        if (accessToken && (refreshToken || loggedInVia === "pecha")) {
+            setIsLoggedIn(true);
+        } else {
+            setIsLoggedIn(false);
+        }
+        setIsAuthLoading(false);
+    }, []);
 
     const login = (accessToken, refreshToken = null) => {
         sessionStorage.setItem(ACCESS_TOKEN, accessToken);
@@ -21,8 +34,7 @@ export const PechaAuthProvider = ({ children }) => {
         localStorage.removeItem("refreshToken");
         setIsLoggedIn(false);
     };
-    const contextValue = useMemo(() => ({ isLoggedIn, login, logout }), [isLoggedIn]);
-
+    const contextValue = useMemo(() => ({ isLoggedIn, login, logout, isAuthLoading }), [isLoggedIn, isAuthLoading]);
 
     return (
         <AuthContext.Provider value={contextValue}>


### PR DESCRIPTION
currently we have done a minimum setup for redirect logic. which include adding it in session storage. but when a user refresh. there seems to be a 2 sec or less of loading time which makes the ui less intiutive. 

this task will be to create a loading ui for the login and signup at navbar and to improve the redirect logic.

try testing with either local storage (which doesnt perish) or try with session storage. either way the outcome should be such that suppose a user refresh in sheet. he or she should be able to stay back in the sheet page.

currently it is doing some bug. here is the steps to see that

   1.login.

    go to commmunity page from navbar

    create a sheet.

    refresh the page.

    you will see is it goes to the /login for 1 sec

    then it will take you back to the home.

this is primarily due to a logic mismatch in redirect. cause during the load the islogin is turning false making it redirect back to /login. fix this issue such that the desirable outcome should be there.