### PR TITLE
Sheet split view

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import { useAuth0 } from "@auth0/auth0-react";
 import { setFontVariables } from "./config/commonConfigs.js";
 import Sheets from "./components/sheets/Sheets.jsx";
 import SheetDetailPage from "./components/sheets/view-sheet/SheetDetailPage.jsx";
+import SheetChapters from "./components/chapterV2/SheetChapters.jsx";
 
 const tokenExpiryTime = import.meta.env.VITE_TOKEN_EXPIRY_TIME_SEC;
 const Collections = lazy(() => import("./components/collections/Collections.jsx"));
@@ -132,7 +133,7 @@ function App() {
               <Route path="/search" element={<SearchResultsPage/>}/>
               <Route path="*" element={<Collections/>}/>
               <Route path="/sheets/:id" element={<Sheets/>}/>
-              <Route path="/:username/:sheetSlugAndId" element={<SheetDetailPage/>}/>
+              <Route path="/:username/:sheetSlugAndId" element={<SheetChapters/>}/>
           </Routes>
       </Suspense>
     );

--- a/src/components/chapterV2/Chapters.jsx
+++ b/src/components/chapterV2/Chapters.jsx
@@ -50,7 +50,8 @@ const Chapters = ({
     };
   }, [chapters, versionId]);
 
-  const addChapter = useCallback((chapterInformation, currentChapter) => {
+  const addChapter = useCallback((chapterInformation, currentChapter, isFromSheet = false) => {
+    const maxChapters = isFromSheet ? 2 : 3;
     setChapters(prev => {
       if (prev.length >= maxChapters) return prev;
       

--- a/src/components/chapterV2/Chapters.test.jsx
+++ b/src/components/chapterV2/Chapters.test.jsx
@@ -158,7 +158,7 @@ describe("Chapters Component", () => {
     act(() => {
       container.click(); 
     });
-    expect(screen.getAllByTestId("contents-chapter-mock").length).toBe(1); 
+    expect(screen.getAllByTestId("contents-chapter-mock").length).toBe(2); 
   });
 
   test("uses custom renderChapter function", () => {

--- a/src/components/chapterV2/Chapters.test.jsx
+++ b/src/components/chapterV2/Chapters.test.jsx
@@ -134,4 +134,47 @@ describe("Chapters Component", () => {
     expect(removeItemSpy).toHaveBeenCalledWith("chapters");
     expect(removeItemSpy).toHaveBeenCalledWith("versionId");
   });
+
+  test("renders with initialChapters prop", () => {
+    const initialChapters = [
+      { textId: "init1", contentId: "c1", segmentId: "s1" },
+      { textId: "init2", contentId: "c2", segmentId: "s2" }
+    ];
+    setupSessionStorage({});
+    mockSearchParams.mockReturnValue({ get: () => null });
+    render(<Chapters initialChapters={initialChapters} />);
+    const containers = screen.getAllByTestId("contents-chapter-mock");
+    expect(containers.length).toBe(2);
+    expect(containers[0]).toHaveAttribute("data-textid", "init1");
+    expect(containers[1]).toHaveAttribute("data-textid", "init2");
+  });
+
+  test("respects maxChapters prop", () => {
+    const chapters = [{ textId: "t1", contentId: "c1", segmentId: "s1" }];
+    setupSessionStorage({ chapters });
+    mockSearchParams.mockReturnValue({ get: () => null });
+    render(<Chapters maxChapters={1} />);
+    const container = screen.getByTestId("contents-chapter-mock");
+    act(() => {
+      container.click(); 
+    });
+    expect(screen.getAllByTestId("contents-chapter-mock").length).toBe(1); 
+  });
+
+  test("uses custom renderChapter function", () => {
+    const chapters = [{ textId: "t1", contentId: "c1", segmentId: "s1" }];
+    const customRender = vi.fn((chapter, index, helpers) => (
+      <div data-testid="custom-chapter" data-textid={chapter.textId}>Custom: {chapter.textId}</div>
+    ));
+    setupSessionStorage({ chapters });
+    mockSearchParams.mockReturnValue({ get: () => null });
+    render(<Chapters renderChapter={customRender} />);
+    expect(screen.getByTestId("custom-chapter")).toBeInTheDocument();
+    expect(screen.getByTestId("custom-chapter")).toHaveAttribute("data-textid", "t1");
+    expect(customRender).toHaveBeenCalledWith(
+      expect.objectContaining({ textId: "t1" }),
+      0,
+      expect.objectContaining({ versionId: expect.any(String), addChapter: expect.any(Function), removeChapter: expect.any(Function) })
+    );
+  });
 });

--- a/src/components/chapterV2/SheetChapters.jsx
+++ b/src/components/chapterV2/SheetChapters.jsx
@@ -34,7 +34,7 @@ const SheetChapters = () => {
           addChapter={addChapter}
           removeChapter={removeChapter}
           currentChapter={chapter}
-          totalChapters={2} 
+          totalChapters={3} 
           setVersionId={setVersionId}
           isFromSheet={true}
         />
@@ -45,7 +45,7 @@ const SheetChapters = () => {
   return (
     <Chapters 
       initialChapters={initialChapters}
-      maxChapters={2}
+      maxChapters={3}
       renderChapter={renderChapter}
     />
   );

--- a/src/components/chapterV2/SheetChapters.jsx
+++ b/src/components/chapterV2/SheetChapters.jsx
@@ -1,0 +1,53 @@
+import { useParams } from "react-router-dom";
+import Chapters from "./Chapters";
+import ContentsChapter from "./chapter/ContentsChapter";
+import SheetDetailPage from "../sheets/view-sheet/SheetDetailPage";
+
+const SheetChapters = () => {
+  const { username, sheetSlugAndId } = useParams();
+  
+  const initialChapters = [{
+    type: 'sheet',
+    sheetSlugAndId: sheetSlugAndId,
+    username: username,
+    segmentId: `sheet-${sheetSlugAndId}` 
+  }];
+
+  const renderChapter = (chapter, index, { versionId, addChapter, removeChapter, setVersionId }) => {
+    if (chapter.type === 'sheet') {
+      
+      return (
+        <SheetDetailPage
+          addChapter={addChapter}
+          currentChapter={chapter}
+          setVersionId={setVersionId}
+        />
+      );
+    } else {
+      
+      return (
+        <ContentsChapter
+          textId={chapter.textId}
+          contentId={chapter.contentId}
+          segmentId={chapter.segmentId}
+          versionId={versionId}
+          addChapter={addChapter}
+          removeChapter={removeChapter}
+          currentChapter={chapter}
+          totalChapters={2} 
+          setVersionId={setVersionId}
+        />
+      );
+    }
+  };
+
+  return (
+    <Chapters 
+      initialChapters={initialChapters}
+      maxChapters={2}
+      renderChapter={renderChapter}
+    />
+  );
+};
+
+export default SheetChapters;

--- a/src/components/chapterV2/SheetChapters.jsx
+++ b/src/components/chapterV2/SheetChapters.jsx
@@ -36,6 +36,7 @@ const SheetChapters = () => {
           currentChapter={chapter}
           totalChapters={2} 
           setVersionId={setVersionId}
+          isFromSheet={true}
         />
       );
     }

--- a/src/components/chapterV2/SheetChapters.test.jsx
+++ b/src/components/chapterV2/SheetChapters.test.jsx
@@ -100,8 +100,8 @@ describe("SheetChapters Component", () => {
       expect(chaptersContainer).toBeInTheDocument();
       
       const maxChaptersElement = screen.getByTestId("max-chapters");
-      expect(maxChaptersElement).toHaveAttribute("data-max", "2");
-      expect(maxChaptersElement).toHaveTextContent("Max Chapters: 2");
+      expect(maxChaptersElement).toHaveAttribute("data-max", "3");
+      expect(maxChaptersElement).toHaveTextContent("Max Chapters: 3");
       
       const renderFunctionElement = screen.getByTestId("render-function");
       expect(renderFunctionElement).toHaveAttribute("data-has-render", "true");
@@ -173,11 +173,11 @@ describe("SheetChapters Component", () => {
   });
 
   describe("Chapter Configuration", () => {
-    test("sets maxChapters to 2", () => {
+    test("sets maxChapters to 3", () => {
       renderWithRouter(<SheetChapters />);
       
       const maxChaptersElement = screen.getByTestId("max-chapters");
-      expect(maxChaptersElement).toHaveTextContent("Max Chapters: 2");
+      expect(maxChaptersElement).toHaveTextContent("Max Chapters: 3");
     });
 
     test("creates initial chapter with correct type", () => {
@@ -207,7 +207,7 @@ describe("SheetChapters Component", () => {
       expect(initialChaptersElement).toHaveTextContent("Initial Chapters: 1");
       
       const maxChaptersElement = screen.getByTestId("max-chapters");
-      expect(maxChaptersElement).toHaveAttribute("data-max", "2");
+      expect(maxChaptersElement).toHaveAttribute("data-max", "3");
       
       const renderFunctionElement = screen.getByTestId("render-function");
       expect(renderFunctionElement).toHaveAttribute("data-has-render", "true");

--- a/src/components/chapterV2/SheetChapters.test.jsx
+++ b/src/components/chapterV2/SheetChapters.test.jsx
@@ -1,0 +1,252 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import SheetChapters from "./SheetChapters.jsx";
+
+const mockUseParams = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return {
+    ...actual,
+    useParams: () => mockUseParams(),
+  };
+});
+
+vi.mock("./Chapters", () => ({
+  __esModule: true,
+  default: ({ initialChapters, maxChapters, renderChapter }) => (
+    <div data-testid="chapters-mock">
+      <div data-testid="initial-chapters" data-chapters={JSON.stringify(initialChapters)}>
+        Initial Chapters: {initialChapters?.length || 0}
+      </div>
+      <div data-testid="max-chapters" data-max={maxChapters}>
+        Max Chapters: {maxChapters}
+      </div>
+      <div data-testid="render-function" data-has-render={!!renderChapter}>
+        Has Render Function: {!!renderChapter}
+      </div>
+      {initialChapters?.map((chapter, index) => (
+        <div key={index} data-testid={`chapter-${index}`} data-chapter-type={chapter.type}>
+          {renderChapter && renderChapter(chapter, index, {
+            versionId: "test-version",
+            addChapter: vi.fn(),
+            removeChapter: vi.fn(),
+            setVersionId: vi.fn()
+          })}
+        </div>
+      ))}
+    </div>
+  )
+}));
+
+vi.mock("./chapter/ContentsChapter", () => ({
+  __esModule: true,
+  default: ({ textId, contentId, segmentId, versionId, addChapter, removeChapter, currentChapter, totalChapters, setVersionId }) => (
+    <div data-testid="contents-chapter-mock"
+      data-textid={textId}
+      data-contentid={contentId}
+      data-segmentid={segmentId}
+      data-versionid={versionId}
+      data-totalchapters={totalChapters}
+    >
+      ContentsChapter Mock
+    </div>
+  )
+}));
+
+vi.mock("../sheets/view-sheet/SheetDetailPage", () => ({
+  __esModule: true,
+  default: ({ addChapter, currentChapter, setVersionId }) => (
+    <div data-testid="sheet-detail-page-mock"
+      data-has-addchapter={!!addChapter}
+      data-has-currentchapter={!!currentChapter}
+      data-has-setversionid={!!setVersionId}
+      data-chapter-type={currentChapter?.type}
+      data-sheet-slug-and-id={currentChapter?.sheetSlugAndId}
+      data-username={currentChapter?.username}
+      data-segment-id={currentChapter?.segmentId}
+    >
+      SheetDetailPage Mock
+    </div>
+  )
+}));
+
+const renderWithRouter = (component, { username = "user123", sheetSlugAndId = "sheet456" } = {}) => {
+  mockUseParams.mockReturnValue({ username, sheetSlugAndId });
+  return render(
+    <MemoryRouter>
+      {component}
+    </MemoryRouter>
+  );
+};
+
+describe("SheetChapters Component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseParams.mockReturnValue({ username: "user123", sheetSlugAndId: "sheet456" });
+  });
+
+  describe("Component Rendering", () => {
+    test("renders without crashing", () => {
+      renderWithRouter(<SheetChapters />);
+      expect(screen.getByTestId("chapters-mock")).toBeInTheDocument();
+    });
+
+    test("passes correct props to Chapters component", () => {
+      renderWithRouter(<SheetChapters />);
+      
+      const chaptersContainer = screen.getByTestId("chapters-mock");
+      expect(chaptersContainer).toBeInTheDocument();
+      
+      const maxChaptersElement = screen.getByTestId("max-chapters");
+      expect(maxChaptersElement).toHaveAttribute("data-max", "2");
+      expect(maxChaptersElement).toHaveTextContent("Max Chapters: 2");
+      
+      const renderFunctionElement = screen.getByTestId("render-function");
+      expect(renderFunctionElement).toHaveAttribute("data-has-render", "true");
+    });
+
+    test("creates initial chapters with correct structure from URL params", () => {
+      renderWithRouter(<SheetChapters />, { username: "testuser", sheetSlugAndId: "sheet-test-123" });
+      
+      const initialChaptersElement = screen.getByTestId("initial-chapters");
+      const chaptersData = JSON.parse(initialChaptersElement.getAttribute("data-chapters"));
+      
+      expect(chaptersData).toHaveLength(1);
+      expect(chaptersData[0]).toEqual({
+        type: 'sheet',
+        sheetSlugAndId: 'sheet-test-123',
+        username: 'testuser',
+        segmentId: 'sheet-sheet-test-123'
+      });
+    });
+  });
+
+  describe("URL Parameter Handling", () => {
+    test("extracts username and sheetSlugAndId from URL correctly", () => {
+      renderWithRouter(<SheetChapters />, { username: "john_doe", sheetSlugAndId: "my-awesome-sheet-789" });
+      
+      const initialChaptersElement = screen.getByTestId("initial-chapters");
+      const chaptersData = JSON.parse(initialChaptersElement.getAttribute("data-chapters"));
+      
+      expect(chaptersData[0].username).toBe("john_doe");
+      expect(chaptersData[0].sheetSlugAndId).toBe("my-awesome-sheet-789");
+      expect(chaptersData[0].segmentId).toBe("sheet-my-awesome-sheet-789");
+    });
+
+    test("handles URL with special characters", () => {
+      renderWithRouter(<SheetChapters />, { username: "user_123", sheetSlugAndId: "sheet-with-dashes-456" });
+      
+      const initialChaptersElement = screen.getByTestId("initial-chapters");
+      const chaptersData = JSON.parse(initialChaptersElement.getAttribute("data-chapters"));
+      
+      expect(chaptersData[0].username).toBe("user_123");
+      expect(chaptersData[0].sheetSlugAndId).toBe("sheet-with-dashes-456");
+    });
+  });
+
+  describe("Chapter Rendering Logic", () => {
+    test("renders SheetDetailPage for sheet type chapter", () => {
+      renderWithRouter(<SheetChapters />, { username: "testuser", sheetSlugAndId: "sheet123" });
+      
+      const sheetDetailPage = screen.getByTestId("sheet-detail-page-mock");
+      expect(sheetDetailPage).toBeInTheDocument();
+      expect(sheetDetailPage).toHaveAttribute("data-has-addchapter", "true");
+      expect(sheetDetailPage).toHaveAttribute("data-has-currentchapter", "true");
+      expect(sheetDetailPage).toHaveAttribute("data-has-setversionid", "true");
+      expect(sheetDetailPage).toHaveAttribute("data-chapter-type", "sheet");
+      expect(sheetDetailPage).toHaveAttribute("data-sheet-slug-and-id", "sheet123");
+      expect(sheetDetailPage).toHaveAttribute("data-username", "testuser");
+      expect(sheetDetailPage).toHaveAttribute("data-segment-id", "sheet-sheet123");
+    });
+
+    test("renders ContentsChapter for non-sheet type chapter", () => {
+      renderWithRouter(<SheetChapters />);
+      
+      const chaptersContainer = screen.getByTestId("chapters-mock");
+      expect(chaptersContainer).toBeInTheDocument();
+      
+      const renderFunctionElement = screen.getByTestId("render-function");
+      expect(renderFunctionElement).toHaveAttribute("data-has-render", "true");
+    });
+  });
+
+  describe("Chapter Configuration", () => {
+    test("sets maxChapters to 2", () => {
+      renderWithRouter(<SheetChapters />);
+      
+      const maxChaptersElement = screen.getByTestId("max-chapters");
+      expect(maxChaptersElement).toHaveTextContent("Max Chapters: 2");
+    });
+
+    test("creates initial chapter with correct type", () => {
+      renderWithRouter(<SheetChapters />);
+      
+      const initialChaptersElement = screen.getByTestId("initial-chapters");
+      const chaptersData = JSON.parse(initialChaptersElement.getAttribute("data-chapters"));
+      
+      expect(chaptersData[0].type).toBe("sheet");
+    });
+
+    test("generates correct segmentId format", () => {
+      renderWithRouter(<SheetChapters />, { username: "user", sheetSlugAndId: "sheet-example-123" });
+      
+      const initialChaptersElement = screen.getByTestId("initial-chapters");
+      const chaptersData = JSON.parse(initialChaptersElement.getAttribute("data-chapters"));
+      
+      expect(chaptersData[0].segmentId).toBe("sheet-sheet-example-123");
+    });
+  });
+
+  describe("Integration with Chapters Component", () => {
+    test("passes all required props to Chapters", () => {
+      renderWithRouter(<SheetChapters />);
+      
+      const initialChaptersElement = screen.getByTestId("initial-chapters");
+      expect(initialChaptersElement).toHaveTextContent("Initial Chapters: 1");
+      
+      const maxChaptersElement = screen.getByTestId("max-chapters");
+      expect(maxChaptersElement).toHaveAttribute("data-max", "2");
+      
+      const renderFunctionElement = screen.getByTestId("render-function");
+      expect(renderFunctionElement).toHaveAttribute("data-has-render", "true");
+    });
+
+    test("initial chapter structure is complete", () => {
+      renderWithRouter(<SheetChapters />, { username: "alice", sheetSlugAndId: "my-sheet-999" });
+      
+      const initialChaptersElement = screen.getByTestId("initial-chapters");
+      const chaptersData = JSON.parse(initialChaptersElement.getAttribute("data-chapters"));
+      
+      const chapter = chaptersData[0];
+      expect(chapter).toHaveProperty("type", "sheet");
+      expect(chapter).toHaveProperty("sheetSlugAndId", "my-sheet-999");
+      expect(chapter).toHaveProperty("username", "alice");
+      expect(chapter).toHaveProperty("segmentId", "sheet-my-sheet-999");
+    });
+  });
+
+  describe("Edge Cases", () => {
+    test("handles empty or undefined URL parameters gracefully", () => {
+      renderWithRouter(<SheetChapters />, { username: "", sheetSlugAndId: "" });
+      
+      const initialChaptersElement = screen.getByTestId("initial-chapters");
+      const chaptersData = JSON.parse(initialChaptersElement.getAttribute("data-chapters"));
+      
+      expect(chaptersData[0].username).toBe("");
+      expect(chaptersData[0].sheetSlugAndId).toBe("");
+      expect(chaptersData[0].segmentId).toBe("sheet-");
+    });
+
+    test("maintains component structure with unusual URL formats", () => {
+      renderWithRouter(<SheetChapters />, { username: "user123", sheetSlugAndId: "" });
+      
+      const chaptersContainer = screen.getByTestId("chapters-mock");
+      expect(chaptersContainer).toBeInTheDocument();
+      
+      const initialChaptersElement = screen.getByTestId("initial-chapters");
+      expect(initialChaptersElement).toHaveTextContent("Initial Chapters: 1");
+    });
+  });
+});

--- a/src/components/chapterV2/chapter/ContentsChapter.jsx
+++ b/src/components/chapterV2/chapter/ContentsChapter.jsx
@@ -25,7 +25,7 @@ const fetchContentDetails = async ({ pageParam = null, queryKey }) => {
   return data;
 };
 
-const ContentsChapter = ({ textId, contentId, segmentId, versionId, addChapter, removeChapter, currentChapter, totalChapters, setVersionId }) => {
+const ContentsChapter = ({ textId, contentId, segmentId, isFromSheet = false, versionId, addChapter, removeChapter, currentChapter, totalChapters, setVersionId }) => {
   const [viewMode, setViewMode] = useState(VIEW_MODES.SOURCE);
   const [showTableOfContents, setShowTableOfContents] = useState(false);
   const [currentSegmentId, setCurrentSegmentId] = useState(segmentId)
@@ -49,12 +49,12 @@ const ContentsChapter = ({ textId, contentId, segmentId, versionId, addChapter, 
     ["content", textId, contentId, versionId, size, currentSegmentId],
     fetchContentDetails,
     {
-      getNextPageParam: (lastPage) => {
+      getNextPageParam: isFromSheet ? undefined : (lastPage) => {
         if (lastPage?.current_segment_position === lastPage?.total_segments) return null;
         const lastSegmentId = getLastSegmentId(lastPage.content.sections);
         return { segmentId: lastSegmentId, direction: "next" };
       },
-      getPreviousPageParam: (firstPage) => {
+      getPreviousPageParam: isFromSheet ? undefined : (firstPage) => {
         if (firstPage?.current_segment_position === 1) return null;
         const firstSegmentId = getFirstSegmentId(firstPage.content.sections);
         return { segmentId: firstSegmentId, direction: "previous" };

--- a/src/components/collections/Collections.jsx
+++ b/src/components/collections/Collections.jsx
@@ -12,7 +12,7 @@ import PropTypes from "prop-types";
 export const fetchCollections = async () => {
   const storedLanguage = localStorage.getItem(LANGUAGE);
   const language = (storedLanguage ? mapLanguageCode(storedLanguage) : "bo");
-  const {data} = await axiosInstance.get("api/v1/collections", {
+  const {data} = await axiosInstance.get("/api/v1/collections", {
     params: {
       language,
       limit: 10,

--- a/src/components/collections/Collections.test.jsx
+++ b/src/components/collections/Collections.test.jsx
@@ -213,7 +213,7 @@ describe("Collections Component", () => {
     axiosInstance.get.mockResolvedValueOnce({ data: mockCollectionsData });
 
     const result = await fetchCollections();
-    expect(axiosInstance.get).toHaveBeenCalledWith("api/v1/collections", {
+    expect(axiosInstance.get).toHaveBeenCalledWith("/api/v1/collections", {
       params: {
         language: "en",
         limit: 10,

--- a/src/components/sheets/local-components/sheet-share/sheetShare.jsx
+++ b/src/components/sheets/local-components/sheet-share/sheetShare.jsx
@@ -83,8 +83,9 @@ const SheetShare = () => {
             target="_blank"
             rel="noopener noreferrer"
           >
-            <FaTwitter className="share-icon" />
-            <span>Share on X</span>
+              <FaFacebook className="share-icon" />
+              <span>Share on Facebook</span>
+           
           </a>
           
           <a 
@@ -93,8 +94,8 @@ const SheetShare = () => {
             target="_blank"
             rel="noopener noreferrer"
           >
-            <FaFacebook className="share-icon" />
-            <span>Share on Facebook</span>
+           <FaTwitter className="share-icon" />
+           <span>Share on X</span>
           </a>
           
         </div>

--- a/src/components/sheets/view-sheet/SheetDetailPage.jsx
+++ b/src/components/sheets/view-sheet/SheetDetailPage.jsx
@@ -10,7 +10,6 @@ import axiosInstance from '../../../config/axios-config';
 import { useQuery, useMutation, useQueryClient } from 'react-query';
 import { useTranslate } from '@tolgee/react';
 import {getLanguageClass} from "../../../utils/helperFunctions.jsx";
-import Resources from "../../chapterV2/utils/resources/Resources.jsx";
 import { SheetDeleteModal } from '../local-components/modals/sheet-delete-modal/SheetDeleteModal';
 import SheetShare from '../local-components/sheet-share/sheetShare';
 import PropTypes from 'prop-types';
@@ -98,8 +97,6 @@ const SheetDetailPage = ({ addChapter, currentChapter } = {}) => {
     queryKey:['sheetData',sheetId],
     queryFn:()=>fetchSheetData(sheetId)
   })
-  const [segmentId, setSegmentId] = useState(null);
-  const [searchParams, setSearchParams] = useSearchParams();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const { isResourcesPanelOpen, openResourcesPanel, closeResourcesPanel } = usePanelContext();
 
@@ -152,7 +149,7 @@ const SheetDetailPage = ({ addChapter, currentChapter } = {}) => {
               <div className={getLanguageClass(segment.language || 'en')}>
                 <p className={`${getLanguageClass(segment.language || 'bo')}`} dangerouslySetInnerHTML={{__html:segment.content}}/>
               </div>
-              <p className="pecha-title">"{segment.text_title}"</p>
+              <p className="pecha-title">{segment.text_title}</p>
             </div>
           </button>
         );

--- a/src/components/sheets/view-sheet/SheetDetailPage.jsx
+++ b/src/components/sheets/view-sheet/SheetDetailPage.jsx
@@ -140,7 +140,7 @@ const SheetDetailPage = ({ addChapter, currentChapter } = {}) => {
                 addChapter({ 
                   textId: textId, 
                   segmentId: segment.segment_id,
-                }, currentChapter);
+                }, currentChapter, true); 
               }
             }
           >

--- a/src/components/sheets/view-sheet/SheetDetailPage.test.jsx
+++ b/src/components/sheets/view-sheet/SheetDetailPage.test.jsx
@@ -373,7 +373,8 @@ describe("SheetDetailPage Component", () => {
           textId: "mock-text-id-123",
           segmentId: "segment1"
         },
-        mockCurrentChapter
+        mockCurrentChapter,
+        true
       );
     });
   });
@@ -391,7 +392,8 @@ describe("SheetDetailPage Component", () => {
           textId: "mock-text-id-123",
           segmentId: "segment1"
         },
-        mockCurrentChapter
+        mockCurrentChapter,
+        true
       );
     });
   });
@@ -414,7 +416,8 @@ describe("SheetDetailPage Component", () => {
           textId: "fallback-text-id-456",
           segmentId: "segment1"
         },
-        mockCurrentChapter
+        mockCurrentChapter,
+        true
       );
     });
   });
@@ -435,7 +438,8 @@ describe("SheetDetailPage Component", () => {
           textId: undefined,
           segmentId: "segment1"
         },
-        mockCurrentChapter
+        mockCurrentChapter,
+        true
       );
     });
   });
@@ -480,7 +484,8 @@ describe("SheetDetailPage Component", () => {
           textId: "async-text-id",
           segmentId: "segment1"
         },
-        mockCurrentChapter
+        mockCurrentChapter,
+        true
       );
     });
   });


### PR DESCRIPTION
Changes : 
made Chapters component reusable in sheetChapters which is a wrapper for allowing addChapter function work in SheetDetailPage 
Requirement : 
In sheetDetailPage, previously if we click on a segment it will open resourcepanel, now it instead of resourcepanel, it will open the text that contains the segment in a splitscreen view.  (For sheet, max chapter open or split view is 2 and for text its same as before 3) 

<img width="1904" height="917" alt="image" src="https://github.com/user-attachments/assets/2eb1aa04-fff5-46fd-8fc3-2f021616cba0" />
