### PR TITLE
fix : styling

### DIFF
--- a/src/components/chapterV2/chapter/helpers/ChapterHook.scss
+++ b/src/components/chapterV2/chapter/helpers/ChapterHook.scss
@@ -12,9 +12,10 @@
   .main-content {
     overflow-y: auto;
     width: 100%;
+    display: flex;
     .outmost-container{
-      width: 70%;
-      margin: 0 auto;
+      width: 100%;
+      
       .scroll-sentinel {
         height: 20px;
         width: 100%;
@@ -37,9 +38,50 @@
       .outer-container{
         display: flex;
         flex-direction: column;
-        align-items: start;
         width: 80%;
+        padding: 0 10px;
+        align-items: center;
         margin: 0 auto;
+        .segment-container{
+            display: flex;
+            align-items: flex-start;
+            margin-top: 10px;
+            width: 400px;
+            @media (max-width: 768px) {
+              width: 100%;
+            }
+            &.highlighted-segment {
+              background-color: #f0f7ff;
+            }
+            .segment-number{
+              margin-right: 2rem;
+            }
+            .segment-content{
+              display: flex;
+              flex-direction: column;
+              align-items: flex-start;
+              width: 100%;
+            }
+            .footnote-marker {
+              cursor: pointer;
+              color: #007bff;
+              font-weight: bold;
+              z-index: 2;
+              padding: 0 2px;
+            }
+            .footnote {
+              display: none;
+              color: #484848;
+              margin: 4px;
+              font-size: 0.9rem;
+              background-color: #f7f7f7;
+              padding: 2px 5px;
+              border-radius: 3px;
+              &.active {
+                display: inline;
+              }
+            }
+          }
       }
       h2{
         margin-bottom: 10px;
@@ -49,43 +91,7 @@
         border: none;   
         text-align: start;
       }
-      .segment-container{
-          display: flex;
-          align-items: flex-start;
-          margin-top: 10px;
-          width: 100%;
-          &.highlighted-segment {
-            background-color: #f0f7ff;
-          }
-          .segment-number{
-            margin-right: 2rem;
-          }
-          .segment-content{
-            display: flex;
-            flex-direction: column;
-            align-items: flex-start;
-            width: 100%;
-          }
-          .footnote-marker {
-            cursor: pointer;
-            color: #007bff;
-            font-weight: bold;
-            z-index: 2;
-            padding: 0 2px;
-          }
-          .footnote {
-            display: none;
-            color: #484848;
-            margin: 4px;
-            font-size: 0.9rem;
-            background-color: #f7f7f7;
-            padding: 2px 5px;
-            border-radius: 3px;
-            &.active {
-              display: inline;
-            }
-          }
-        }
+
       }
     }
   }


### PR DESCRIPTION
fixes #194 #193 and #212 
centralized the text both in solo and double screen

| Double | Solo | 
|------------|-----------------|
| <img width="1512" height="982" alt="Screenshot 2025-09-27 at 3 45 56 PM" src="https://github.com/user-attachments/assets/b8d31f94-e5d2-4f45-b4d8-b7c5a910512c" /> | <img width="1512" height="982" alt="Screenshot 2025-09-27 at 3 45 47 PM" src="https://github.com/user-attachments/assets/6bdcacd2-e5cf-4f88-aad7-864188d04a74" /> |


### what went wrong
 best way seems to be using a fix width except for smaller screen. the problem was more of a problem with the text. some text doesnt have any breaking tags like the below. which was making the % pixel useless and sending the text way too left.  making it look like it is not centralized.
| what we except | what we get | 
|------------|-----------------|
| <img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/2da25f13-a7f7-4919-90ca-1cf350f68c32" /> | <img width="1512" height="982" alt="Screenshot 2025-09-27 at 3 30 57 PM" src="https://github.com/user-attachments/assets/c7bba650-2eee-4351-b509-c98bdfa9d216" /> |


